### PR TITLE
Feat(#28)/역대 전공동아리 목록조회

### DIFF
--- a/src/main/java/co/kr/muldum/application/history/HistoryUseCase.java
+++ b/src/main/java/co/kr/muldum/application/history/HistoryUseCase.java
@@ -1,0 +1,24 @@
+package co.kr.muldum.application.history;
+
+import co.kr.muldum.application.history.dto.HistoryResponseDto;
+import co.kr.muldum.domain.history.model.History;
+import co.kr.muldum.domain.history.service.HistoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class HistoryUseCase {
+
+    private final HistoryService historyService;
+
+    public List<HistoryResponseDto> getHistories(Integer generation) {
+        List<History> histories = historyService.findHistories(generation);
+        return histories.stream()
+                .map(HistoryResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/co/kr/muldum/application/history/HistoryUseCase.java
+++ b/src/main/java/co/kr/muldum/application/history/HistoryUseCase.java
@@ -1,5 +1,6 @@
 package co.kr.muldum.application.history;
 
+import org.springframework.transaction.annotation.Transactional;
 import co.kr.muldum.application.history.dto.HistoryResponseDto;
 import co.kr.muldum.domain.history.model.History;
 import co.kr.muldum.domain.history.service.HistoryService;
@@ -15,10 +16,11 @@ public class HistoryUseCase {
 
     private final HistoryService historyService;
 
+    @Transactional(readOnly = true)
     public List<HistoryResponseDto> getHistories(Integer generation) {
         List<History> histories = historyService.findHistories(generation);
         return histories.stream()
                 .map(HistoryResponseDto::fromEntity)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/src/main/java/co/kr/muldum/application/history/dto/HistoryResponseDto.java
+++ b/src/main/java/co/kr/muldum/application/history/dto/HistoryResponseDto.java
@@ -1,0 +1,50 @@
+package co.kr.muldum.application.history.dto;
+
+import co.kr.muldum.domain.history.model.History;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HistoryResponseDto {
+    private Long id;
+    private String name;
+    private Integer generation;
+    private String description;
+    private String logoUrl;
+    private List<AwardDto> awards;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AwardDto {
+        private String awardType;
+        private LocalDate givenAt;
+    }
+
+    public static HistoryResponseDto fromEntity(History h) {
+        return HistoryResponseDto.builder()
+                .id(h.getId())
+                .name(h.getName())
+                .generation(h.getGeneration())
+                .description(h.getDescription())
+                .logoUrl(h.getLogoUrl())
+                .awards(h.getAwards() == null ? List.of() :
+                        h.getAwards().stream()
+                                .map(a -> AwardDto.builder()
+                                        .awardType(a.getAwardType())
+                                        .givenAt(a.getGivenAt())
+                                        .build())
+                                .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/co/kr/muldum/domain/history/model/History.java
+++ b/src/main/java/co/kr/muldum/domain/history/model/History.java
@@ -1,0 +1,53 @@
+package co.kr.muldum.domain.history.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "histories")
+public class History {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Integer generation;
+
+    @Column(columnDefinition = "text")
+    private String description;
+
+    @Column(name = "logo_url")
+    private String logoUrl;
+
+    @ElementCollection
+    @CollectionTable(name = "history_awards", joinColumns = @JoinColumn(name = "history_id"))
+    private List<HistoryAward> awards = new ArrayList<>();
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Embeddable
+    public static class HistoryAward {
+
+        @Column(name = "award_type", nullable = false)
+        private String awardType;
+
+        @Column(name = "given_at")
+        private LocalDate givenAt;
+    }
+}

--- a/src/main/java/co/kr/muldum/domain/history/repository/HistoryRepository.java
+++ b/src/main/java/co/kr/muldum/domain/history/repository/HistoryRepository.java
@@ -1,0 +1,12 @@
+package co.kr.muldum.domain.history.repository;
+
+import co.kr.muldum.domain.history.model.History;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface HistoryRepository extends JpaRepository<History, Long> {
+    List<History> findByGeneration(Integer generation);
+}

--- a/src/main/java/co/kr/muldum/domain/history/service/HistoryService.java
+++ b/src/main/java/co/kr/muldum/domain/history/service/HistoryService.java
@@ -1,0 +1,22 @@
+package co.kr.muldum.domain.history.service;
+
+import co.kr.muldum.domain.history.model.History;
+import co.kr.muldum.domain.history.repository.HistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class HistoryService {
+
+    private final HistoryRepository historyRepository;
+
+    public List<History> findHistories(Integer generation){
+        if (generation == null) {
+            return historyRepository.findAll();
+        }
+        return historyRepository.findByGeneration(generation);
+    }
+}

--- a/src/main/java/co/kr/muldum/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/co/kr/muldum/global/security/JwtAuthenticationFilter.java
@@ -27,9 +27,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain)
             throws ServletException, IOException {
 
-        // 1. 요청에서 토큰 꺼내기 (Authorization 헤더)
+        String path = request.getRequestURI();
+        if (path.startsWith("/ara/auth")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String token = jwtTokenResolver.resolveToken(request);
-        // 2. 토큰이 유효하다면, 인증 정보 설정하기
         if (token != null && jwtTokenResolver.validateToken(token)) {
             log.info("[JwtFilter] 유효한 토큰입니다.");
             SecurityContextHolder.getContext().setAuthentication(
@@ -37,7 +41,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             );
         }
 
-        // 3. 다음 필터로 넘어가기
         filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/co/kr/muldum/presentation/history/HistoryController.java
+++ b/src/main/java/co/kr/muldum/presentation/history/HistoryController.java
@@ -1,0 +1,26 @@
+package co.kr.muldum.presentation.history;
+
+import co.kr.muldum.application.history.HistoryUseCase;
+import co.kr.muldum.application.history.dto.HistoryResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/ara/history")
+@RequiredArgsConstructor
+public class HistoryController {
+
+    private final HistoryUseCase historyUseCase;
+
+    @GetMapping
+    public List<HistoryResponseDto> getHistories(
+            @RequestParam(required = false) Integer generation
+    ) {
+        return historyUseCase.getHistories(generation);
+    }
+}


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #28 

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 역대 전공동아리 목록 조회 시 read-only 트랜잭션을 적용하고, Stream 수집 방식을 Collectors.toList() 대신 Java 16+의 .toList()로 변경하여 코드 가독성과 성능을 개선했습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- @Transactional(readOnly = true) 적용하여 조회 성능 최적화
- Stream 수집 방식 변경 (Collectors.toList() → .toList())


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [ ] 테스트를 완료했나요?
- [ ] API 문서를 작성했나요?
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

- 데이터 조회 API의 특성을 고려해 읽기 전용 트랜잭션을 적용하여 불필요한 쓰기 락을 방지했습니다.
