### PR TITLE
Feat(#105)/전공동아리-팀-조회

### DIFF
--- a/src/main/java/co/kr/muldum/application/teamspace/TeamspaceService.java
+++ b/src/main/java/co/kr/muldum/application/teamspace/TeamspaceService.java
@@ -131,4 +131,33 @@ public class TeamspaceService {
                 .teams(teamDtos)
                 .build();
     }
+
+    // 전공동아리 팀 조회
+    @Transactional(readOnly = true)
+    public TeamspaceResponseDto getMajorTeams() {
+        // MAJOR 타입 팀 조회
+        List<Team> teams = teamRepository.findByType(TeamType.MAJOR);
+
+        List<TeamspaceTeamDto> teamDtos = teams.stream()
+                .map(team -> {
+                    List<TeamspaceMember> members = teamspaceMemberRepository.findByTeam(team);
+                    List<TeamspaceMemberDto> memberDtos = members.stream()
+                            .map(member -> TeamspaceMemberDto.builder()
+                                    .userId(member.getUser().getId())
+                                    .userName(member.getUser().getName())
+                                    .build())
+                            .toList();
+
+                    return TeamspaceTeamDto.builder()
+                            .teamId(team.getId())
+                            .teamName(team.getName())
+                            .members(memberDtos)
+                            .build();
+                })
+                .toList();
+
+        return TeamspaceResponseDto.builder()
+                .teams(teamDtos)
+                .build();
+    }
 }

--- a/src/main/java/co/kr/muldum/presentation/teamspace/TeamspaceController.java
+++ b/src/main/java/co/kr/muldum/presentation/teamspace/TeamspaceController.java
@@ -28,4 +28,10 @@ public class TeamspaceController {
     public TeamspaceResponseDto getTeamspace() {
         return teamspaceService.getTeamspace();
     }
+
+    // 전공동아리 팀 조회
+    @GetMapping("/ara/teamspace/major")
+    public TeamspaceResponseDto getMajorTeams() {
+        return teamspaceService.getMajorTeams();
+    }
 }


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #105

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 전공동아리 팀 목록을 조회하는 API를 추가했습니다

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- TeamspaceService#getMajorTeams() 구현 
- TeamType.MAJOR 팀만 조회, 팀별 멤버 리스트 매핑


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 메이저 팀 목록 및 팀원 정보 조회 API 추가: GET /ara/teamspace/major
  - 팀별 식별자/이름과 구성원 식별자/이름을 포함해 일괄 응답
  - 클라이언트가 메이저 팀만 필터링해 손쉽게 수신 가능
  - 기존 네트워크 팀 조회 엔드포인트는 변경 없음

<!-- end of auto-generated comment: release notes by coderabbit.ai -->