### PR TITLE
Refactor(#106)/공지 삭제 시 s3 함께 삭제

### DIFF
--- a/src/main/java/co/kr/muldum/application/notice/command/NoticeCommandService.java
+++ b/src/main/java/co/kr/muldum/application/notice/command/NoticeCommandService.java
@@ -116,7 +116,7 @@ public class NoticeCommandService {
       }
       return URLDecoder.decode(path, StandardCharsets.UTF_8);
     } catch (Exception e) {
-      throw new IllegalArgumentException("잘못된 S3 URL 형식: " + fileUrl, e);
+      throw new IllegalArgumentException("잘못된 S3 URL 형식: " + e);
     }
   }
 

--- a/src/main/java/co/kr/muldum/global/config/S3Config.java
+++ b/src/main/java/co/kr/muldum/global/config/S3Config.java
@@ -8,6 +8,8 @@ import org.springframework.context.annotation.Primary;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
 @RequiredArgsConstructor
@@ -26,5 +28,15 @@ public class S3Config {
   @Bean
   public AwsCredentialsProvider credentialsProvider() {
     return this::awsCredentials;
+  }
+
+  @Bean
+  public S3Client s3Client(
+          AwsCredentialsProvider awsCredentialsProvider
+  ) {
+    return S3Client.builder()
+            .region(Region.of(s3Properties.getRegion()))
+            .credentialsProvider(awsCredentialsProvider)
+            .build();
   }
 }

--- a/src/main/java/co/kr/muldum/global/properties/S3Properties.java
+++ b/src/main/java/co/kr/muldum/global/properties/S3Properties.java
@@ -13,4 +13,5 @@ public class S3Properties {
   private String bucket;
   private String accessKey;
   private String secretKey;
+  private String region;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,7 @@ spring:
         bucket: ${AWS_BUCKET_NAME}
         access-key: ${AWS_BUCKET_ACCESS_KEY}
         secret-key: ${AWS_BUCKET_SECRET_KEY}
+        region: ${AWS_BUCKET_REGION}
 jwt:
   secret-key: ${JWT_SECRET_KEY}
 


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #106 

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 공지 삭제 시 s3 객체도 함께 삭제되도록 개선했습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- 공지 삭제 시 s3 key로 객체를 삭제하는 로직을 추가했습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)

추후에 구현할 때에는 type을 받아와서 notice/s3-객체 형식으로 저장하여 공지 관련 파일과 다른 파일을 구분할 수 있는 폴더를 지정하면 좋을것 같습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 공지 삭제 시 연결된 첨부 파일이 클라우드 스토리지(S3)에서도 함께 삭제되도록 개선되었습니다.
- 버그 수정
  - 일부 상황에서 공지 삭제 후 스토리지에 파일이 남을 수 있던 문제를 해결했습니다.
- 작업
  - S3 클라이언트 빈이 추가되어 리전 기반 설정을 지원합니다.
  - 애플리케이션 설정에 S3 리전 값(spring.cloud.aws.s3.region)이 추가되었습니다(AWS_BUCKET_REGION 필요).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->